### PR TITLE
deps: remove huggingface-cli

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 llama-cpp-python[server]
 gradio
 openai
-huggingface-cli
 huggingface_hub
 torch
 transformers


### PR DESCRIPTION
> But the [huggingface-cli](https://pypi.org/project/huggingface-cli/) distributed via the Python Package Index (PyPI) and required by Alibaba's GraphTranslator – installed using pip install huggingface-cli – is fake, imagined by AI and turned real by Lanyado as an experiment.

> He created huggingface-cli in December after seeing it repeatedly hallucinated by generative AI; by February this year, Alibaba was referring to it in GraphTranslator's README instructions rather than the real Hugging Face CLI tool.

https://www.theregister.com/2024/03/28/ai_bots_hallucinate_software_packages/

also relates to https://github.com/huggingface/diffusers/pull/7202